### PR TITLE
Make listing recent files instantaneous (#1)

### DIFF
--- a/src/JPSoftworks.RecentFilesExtension/Pages/RecentFilesExtensionPage.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Pages/RecentFilesExtensionPage.cs
@@ -9,42 +9,90 @@ using JPSoftworks.RecentFilesExtension.Resources;
 
 namespace JPSoftworks.RecentFilesExtension.Pages;
 
-internal sealed partial class RecentFilesExtensionPage : ListPage
+internal sealed partial class RecentFilesExtensionPage : DynamicListPage, IDisposable
 {
+    private readonly RecentFilesProvider _recentFilesProvider;
+    private readonly RecentFilesLoader _loader;
+    private Guid _searchToken = Guid.Empty;
+
+    private List<IListItem> _loadedItems = [];
+    private bool _sourceChanged = true;
+
     public RecentFilesExtensionPage()
     {
         this.Icon = IconHelpers.FromRelativePath("Assets\\Square20x20Logo.scale-100.png");
         this.Title = Strings.Page_RecentFiles!;
         this.Name = Strings.Page_RecentFiles!;
         this.Id = "com.jpsoftworks.cmdpal.recentfiles";
+
+        this._recentFilesProvider = new RecentFilesProvider();
+        this._loader = new RecentFilesLoader(this._recentFilesProvider);
+        this._loader.SourceChanged += this.OnSourceChanged;
+
+        this.TriggerSearch("");
     }
 
-    public override IListItem[] GetItems()
+    private void OnSourceChanged(object? sender, EventArgs e)
+    {
+        this._sourceChanged = true;
+    }
+
+    public override void UpdateSearchText(string oldSearch, string newSearch)
+    {
+        if (oldSearch != newSearch || newSearch == "" && this._sourceChanged)
+        {
+            this.TriggerSearch(newSearch);
+        }
+    }
+
+    private void TriggerSearch(string newSearch)
     {
         try
         {
-            var recentFiles = RecentFilesProvider.GetRecentFiles();
-            var items = new List<ListItem>();
-
-            foreach (var recentFile in recentFiles)
-            {
-                try
-                {
-                    items.Add(new RecentFileListItem(recentFile));
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError($"Failed to add link {recentFile.FullPath}", ex);
-                }
-            }
-
-            return [.. items];
-
+            this._searchToken = Guid.NewGuid();
+            this._sourceChanged = false;
+            this._loader.Restart(newSearch, this._searchToken);
+            this._loadedItems = [];
+            this.LoadMore();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex);
             throw;
         }
+    }
+
+    public override void LoadMore()
+    {
+        try
+        {
+            this.IsLoading = true;
+            var items = this._loader.LoadNextPage(this._searchToken, CancellationToken.None);
+            this._loadedItems.AddRange(items);
+            this.HasMoreItems = this._loader.HasMore;
+            this.IsLoading = false;
+            this.RaiseItemsChanged(this._loadedItems.Count);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex);
+            throw;
+        }
+    }
+
+    public override IListItem[] GetItems()
+    {
+        if (this._sourceChanged)
+        {
+            this.TriggerSearch(this.SearchText);
+        }
+        return this._loadedItems.ToArray();
+    }
+
+    public void Dispose()
+    {
+        this._loader.SourceChanged -= this.OnSourceChanged;
+        this._loader.Dispose();
+        this._recentFilesProvider.Dispose();
     }
 }

--- a/src/JPSoftworks.RecentFilesExtension/Pages/RecentFilesLoader.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Pages/RecentFilesLoader.cs
@@ -1,0 +1,106 @@
+// ------------------------------------------------------------
+// 
+// Copyright (c) Jiří Polášek. All rights reserved.
+// 
+// ------------------------------------------------------------
+
+using JPSoftworks.RecentFilesExtension.Model;
+
+namespace JPSoftworks.RecentFilesExtension.Pages;
+
+internal sealed partial class RecentFilesLoader : IDisposable
+{
+    private readonly int _pageSize;
+    private readonly RecentFilesProvider _recentFilesProvider;
+
+    private List<IRecentFile> _allFiles;
+    private List<IRecentFile> _filteredFiles;
+    private int _cursor;
+    private string _currentQuery = string.Empty;
+    private Guid _currentSearchToken;
+
+    /// <summary>
+    /// Raised whenever the underlying recent‐files list changes (e.g. you might clear your UI and restart).
+    /// </summary>
+    public event EventHandler? SourceChanged;
+
+    public RecentFilesLoader(RecentFilesProvider recentFilesProvider, int pageSize = 20)
+    {
+        ArgumentNullException.ThrowIfNull(recentFilesProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(pageSize, 0);
+
+        this._pageSize = pageSize;
+        this._recentFilesProvider = recentFilesProvider;
+
+        this._allFiles = this._recentFilesProvider.GetRecentFiles().ToList();
+        this._filteredFiles = this._allFiles;
+
+        this._recentFilesProvider.RecentFilesChanged += this.OnRecentFilesChanged;
+    }
+
+    private void OnRecentFilesChanged(object? sender, IList<IRecentFile> newList)
+    {
+        this._allFiles = newList.ToList();
+        this.ApplyFilter(this._currentQuery);
+        this.SourceChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Resets the filter to a new search string (empty = no filter) and rewinds paging.
+    /// </summary>
+    public void Restart(string? searchQuery, Guid searchToken)
+    {
+        this._currentSearchToken = searchToken;
+        this.ApplyFilter(searchQuery ?? string.Empty);
+    }
+
+    private void ApplyFilter(string query)
+    {
+        this._currentQuery = query;
+        this._cursor = 0;
+        this._filteredFiles = string.IsNullOrWhiteSpace(query)
+            ? this._allFiles
+            : [.. this._allFiles.Where(Filter)];
+
+        return;
+
+        bool Filter(IRecentFile recentFile)
+        {
+            return recentFile.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                   recentFile.TargetPath.Contains(query, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// True if there’s more data to page through.
+    /// </summary>
+    public bool HasMore => this._cursor < this._filteredFiles.Count;
+
+    /// <summary>
+    /// Loads the next page of entries, including async thumbnail extraction.
+    /// </summary>
+    public IList<RecentFileListItem> LoadNextPage(Guid searchToken, CancellationToken ct = default)
+    {
+        if (this._currentSearchToken != searchToken)
+        {
+            return [];
+        }
+
+        List<IRecentFile> slice = this._filteredFiles.Skip(this._cursor).Take(this._pageSize).ToList();
+        this._cursor += slice.Count;
+
+        var entries = new List<RecentFileListItem>(slice.Count);
+        foreach (var shortcut in slice)
+        {
+            ct.ThrowIfCancellationRequested();
+            entries.Add(new RecentFileListItem(shortcut));
+        }
+
+        return this._currentSearchToken != searchToken ? [] : entries;
+    }
+
+    public void Dispose()
+    {
+        this._recentFilesProvider.RecentFilesChanged -= this.OnRecentFilesChanged;
+    }
+}


### PR DESCRIPTION
Improves performance of recent files listing by ensuring the list is always up to date and loaded incrementally in the background.

- `RecentFilesProvider` now maintains a current list of recent files with background updates
- `RecentFilesLoader` performs incremental loading and transforms results into list items
- `RecentFilesExtensionPage` now derives from `DynamicListPage` for consistency
- Increased recent files max limit to 500