### PR TITLE
Enable globbing support for search (#2)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />

--- a/src/JPSoftworks.RecentFilesExtension/JPSoftworks.RecentFilesExtension.csproj
+++ b/src/JPSoftworks.RecentFilesExtension/JPSoftworks.RecentFilesExtension.csproj
@@ -37,6 +37,7 @@
     <ProjectCapability Include="Msix" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="DotNet.Glob" />
     <PackageReference Include="Microsoft.CommandPalette.Extensions" />
     <PackageReference Include="Microsoft.Windows.CsWin32">
       <PrivateAssets>all</PrivateAssets>

--- a/src/JPSoftworks.RecentFilesExtension/Pages/RecentFilesLoader.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Pages/RecentFilesLoader.cs
@@ -86,9 +86,10 @@ internal sealed partial class RecentFilesLoader : IDisposable
                    recentFile.TargetPath.Contains(q, StringComparison.OrdinalIgnoreCase);
         }
 
-        static bool FilterGlob(IRecentFile arg, Glob glob)
+        static bool FilterGlob(IRecentFile recentFile, Glob glob)
         {
-            return glob.IsMatch(arg.DisplayName) || glob.IsMatch(arg.TargetPath);
+            return glob.IsMatch(recentFile.DisplayName) ||
+                   glob.IsMatch(recentFile.TargetPath);
         }
     }
 


### PR DESCRIPTION
Enable globbing for search (#2)

Adds support for wildcard-based search patterns using globbing when the input includes `*` or `?`. This improves the flexibility and expressiveness of the search functionality.

- Adds `DotNet.Glob` NuGet package
- Switches to glob pattern matching if the search string contains `*` or `?`

Resolves: #2