### PR TITLE
Add UI for end-users if app is started directly and not as an extension

### DIFF
--- a/src/JPSoftworks.RecentFilesExtension/Helpers/MessageBoxHelper.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Helpers/MessageBoxHelper.cs
@@ -1,0 +1,45 @@
+﻿// ------------------------------------------------------------
+// 
+// Copyright (c) Jiří Polášek. All rights reserved.
+// 
+// ------------------------------------------------------------
+
+using System.Runtime.InteropServices;
+
+namespace JPSoftworks.RecentFilesExtension.Helpers;
+
+
+public sealed partial class MessageBoxHelper
+{
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int MessageBox(IntPtr hWnd, string text, string caption, int type);
+
+    public static MessageBoxResult Show(string text, string caption, IconType iconType, MessageBoxType type)
+    {
+        return (MessageBoxResult)MessageBox(IntPtr.Zero, text, caption, (int)type | (int)iconType);
+    }
+
+    public enum IconType
+    {
+        Error = 0x00000010,
+        Help = 0x00000020,
+        Warning = 0x00000030,
+        Info = 0x00000040,
+    }
+
+    public enum MessageBoxType
+    {
+        OK = 0x00000000,
+    }
+
+    public enum MessageBoxResult
+    {
+        OK = 1,
+        Cancel = 2,
+        Abort = 3,
+        Retry = 4,
+        Ignore = 5,
+        Yes = 6,
+        No = 7,
+    }
+}

--- a/src/JPSoftworks.RecentFilesExtension/Helpers/StartupHelper.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Helpers/StartupHelper.cs
@@ -1,0 +1,133 @@
+// ------------------------------------------------------------
+// 
+// Copyright (c) Jiří Polášek. All rights reserved.
+// 
+// ------------------------------------------------------------
+
+using System.Diagnostics;
+using JPSoftworks.RecentFilesExtension.Resources;
+using Windows.ApplicationModel;
+using Windows.Management.Deployment;
+
+namespace JPSoftworks.RecentFilesExtension.Helpers;
+
+/// <summary>
+/// Helper class for user experience related tasks.
+/// </summary>
+internal static class StartupHelper
+{
+    private const string CommandPalettePackageFamilyName = "Microsoft.CommandPalette_8wekyb3d8bbwe";
+    private const string CommandPaletteDevPackageFamilyName = "Microsoft.CommandPalette.Dev_8wekyb3d8bbwe";
+    private const string StorePowerToysLink = "ms-windows-store://pdp/?productid=XP89DCGQ3K6VLD";
+
+    /// <summary>
+    /// Handles direct launch of the application by checking if PowerToys Command Palette is installed
+    /// and attempts to launch it. Shows appropriate messages to the user based on the outcome.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task HandleDirectLaunch()
+    {
+        try
+        {
+            await HandleDirectLaunchCore();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex);
+            MessageBoxHelper.Show(
+                Strings.UserExperienceHelper_GeneralErrorOnStart!,
+                Strings.UserExperienceHelper_ErrorCaption!,
+                MessageBoxHelper.IconType.Error,
+                MessageBoxHelper.MessageBoxType.OK);
+        }
+    }
+
+    private static async Task HandleDirectLaunchCore()
+    {
+        // Let's add something meaningful for the end-user experience.
+        // 1. We are not running as a COM server, so we can show a message box.
+        // 2. We can check if PowerToys Command Palette is installed.
+
+        Logger.Initialize();
+
+        var (retailCommandPalettePackage, devCommandPalettePackage) = FindCommandPaletteApps();
+
+        if (retailCommandPalettePackage != null || devCommandPalettePackage != null)
+        {
+            var started = false;
+            try
+            {
+                if (retailCommandPalettePackage != null)
+                {
+                    started = await StartCommandPalette(retailCommandPalettePackage);
+                }
+                else if (devCommandPalettePackage != null)
+                {
+                    started = await StartCommandPalette(devCommandPalettePackage);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+            }
+
+            if (!started)
+            {
+                MessageBoxHelper.Show(
+                    Strings.UserExperienceHelper_CmdPalIsInstalledButFailedToStart!,
+                    Strings.UserExperienceHelper_InfoCaption!,
+                    MessageBoxHelper.IconType.Warning,
+                    MessageBoxHelper.MessageBoxType.OK);
+            }
+        }
+        else
+        {
+            MessageBoxHelper.Show(
+                Strings.UserExperienceHelper_CmdPalIsNotInstalled!,
+                Strings.UserExperienceHelper_InfoCaption!,
+                MessageBoxHelper.IconType.Warning,
+                MessageBoxHelper.MessageBoxType.OK);
+            try
+            {
+                Process.Start(new ProcessStartInfo(StorePowerToysLink) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                // ignore exception, we just want to open the store link
+                Logger.LogError(ex);
+            }
+        }
+    }
+
+    private static async Task<bool> StartCommandPalette(Package package)
+    {
+        var appEntries = await package.GetAppListEntriesAsync()! ?? [];
+        if (appEntries.Count > 0 && appEntries[0] != null)
+        {
+            return await appEntries[0]!.LaunchAsync()!;
+        }
+
+        return false;
+    }
+
+    private static PackageDetectionResult FindCommandPaletteApps()
+    {
+        try
+        {
+            var packageManager = new PackageManager();
+            var retailPackage = packageManager.FindPackagesForUser("", CommandPalettePackageFamilyName)
+                ?.FirstOrDefault();
+            var devPackage = packageManager.FindPackagesForUser("", CommandPaletteDevPackageFamilyName)
+                ?.FirstOrDefault();
+
+            return new PackageDetectionResult(retailPackage, devPackage);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex);
+            return new PackageDetectionResult(null, null);
+        }
+    }
+
+    private record struct PackageDetectionResult(Package? RetailPackage, Package? DevPackage);
+}

--- a/src/JPSoftworks.RecentFilesExtension/Program.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Program.cs
@@ -4,6 +4,7 @@
 //
 // ------------------------------------------------------------
 
+using JPSoftworks.RecentFilesExtension.Helpers;
 using Shmuelie.WinRTServer;
 using Shmuelie.WinRTServer.CsWinRT;
 
@@ -26,7 +27,7 @@ public static class Program
             server.RegisterClass<RecentFilesExtension, IExtension>(() => extensionInstance);
             server.Start();
 
-            // This will make the main thread wait until the event is signalled by the extension class.
+            // This will make the main thread wait until the event is signaled by the extension class.
             // Since we have single instance of the extension object, we exit as soon as it is disposed.
             extensionDisposedEvent.WaitOne();
 
@@ -35,7 +36,10 @@ public static class Program
         }
         else
         {
-            Console.WriteLine("Not being launched as a Extension... exiting.");
+            // ReSharper disable once LocalizableElement
+            Console.WriteLine("Not being launched as a Extension... exiting");
+
+            await StartupHelper.HandleDirectLaunch();
         }
     }
 }

--- a/src/JPSoftworks.RecentFilesExtension/Properties/launchSettings.json
+++ b/src/JPSoftworks.RecentFilesExtension/Properties/launchSettings.json
@@ -6,6 +6,10 @@
     },
     "JPSoftworks.RecentFilesExtension (Unpackaged)": {
       "commandName": "Project"
+    },
+    "JPSoftworks.RecentFilesExtension (Package) - Launch +no params": {
+      "commandName": "MsixPackage",
+      "doNotLaunchApp": false
     }
   }
 }

--- a/src/JPSoftworks.RecentFilesExtension/Resources/Strings.Designer.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Resources/Strings.Designer.cs
@@ -122,5 +122,56 @@ namespace JPSoftworks.RecentFilesExtension.Resources {
                 return ResourceManager.GetString("Page_RecentFiles_Subtitle", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PowerToys Command Palette is installed, but failed to start.
+        ///
+        ///Please check if the app is running..
+        /// </summary>
+        internal static string UserExperienceHelper_CmdPalIsInstalledButFailedToStart {
+            get {
+                return ResourceManager.GetString("UserExperienceHelper_CmdPalIsInstalledButFailedToStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PowerToys Command Palette is not installed.
+        ///
+        ///Install Microsoft PowerToys to use the extension..
+        /// </summary>
+        internal static string UserExperienceHelper_CmdPalIsNotInstalled {
+            get {
+                return ResourceManager.GetString("UserExperienceHelper_CmdPalIsNotInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error.
+        /// </summary>
+        internal static string UserExperienceHelper_ErrorCaption {
+            get {
+                return ResourceManager.GetString("UserExperienceHelper_ErrorCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred while launching the extension.
+        ///
+        ///Please check the log file for more details..
+        /// </summary>
+        internal static string UserExperienceHelper_GeneralErrorOnStart {
+            get {
+                return ResourceManager.GetString("UserExperienceHelper_GeneralErrorOnStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Information.
+        /// </summary>
+        internal static string UserExperienceHelper_InfoCaption {
+            get {
+                return ResourceManager.GetString("UserExperienceHelper_InfoCaption", resourceCulture);
+            }
+        }
     }
 }

--- a/src/JPSoftworks.RecentFilesExtension/Resources/Strings.resx
+++ b/src/JPSoftworks.RecentFilesExtension/Resources/Strings.resx
@@ -138,4 +138,25 @@
   <data name="Page_RecentFiles_Subtitle" xml:space="preserve">
     <value>Lists recently used or accessed files or folders</value>
   </data>
+  <data name="UserExperienceHelper_CmdPalIsInstalledButFailedToStart" xml:space="preserve">
+	  <value>PowerToys Command Palette is installed, but failed to start.
+
+Please check if the app is running.</value>
+  </data>
+  <data name="UserExperienceHelper_CmdPalIsNotInstalled" xml:space="preserve">
+	  <value>PowerToys Command Palette is not installed.
+
+Install Microsoft PowerToys to use the extension.</value>
+  </data>
+  <data name="UserExperienceHelper_InfoCaption" xml:space="preserve">
+	  <value>Information</value>
+  </data>
+  <data name="UserExperienceHelper_GeneralErrorOnStart" xml:space="preserve">
+	  <value>An error occurred while launching the extension.
+
+Please check the log file for more details.</value>
+  </data>
+  <data name="UserExperienceHelper_ErrorCaption" xml:space="preserve">
+	  <value>Error</value>
+  </data>
 </root>


### PR DESCRIPTION
Detects whether the PowerToys Command Palette is installed by checking for retail or dev versions. If found, the app launches the Command Palette. If not found, it shows a user-friendly notification that PowerToys must be installed and directs the user to the Microsoft Store.

Resolves: #5 